### PR TITLE
Remove typo

### DIFF
--- a/src/analyzeMFT/cli.py
+++ b/src/analyzeMFT/cli.py
@@ -77,7 +77,7 @@ async def main():
             import traceback
             traceback.print_exc()
         sys.exit(1)
- master
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Remove a github placed "master" word that wasn't removed when cleaning the file up.