### PR TITLE
Fix issue #140 : make project pip installable.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 openpyxl==3.0.10
-sqlite3 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 from setuptools import setup, find_packages
-from src.analyzeMFT.constants import VERSION
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
     name='analyzeMFT',
-    version=VERSION,
+    version='3.0.6.6',
     author='Benjamin Cance',
     author_email='bjc@tdx.li',
     package_dir={'': 'src'},
@@ -19,14 +18,12 @@ setup(
     description='Analyze the $MFT from a NTFS filesystem.',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    scripts=['analyzeMFT.py'],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/src/analyzeMFT/constants.py
+++ b/src/analyzeMFT/constants.py
@@ -1,4 +1,5 @@
-VERSION = '3.0.6.6'
+from importlib.metadata import version
+VERSION = version('analyzeMFT')
 
 # File Record Flags
 FILE_RECORD_IN_USE = 0x0001


### PR DESCRIPTION
Hi,

This PR fix issue #140, and allows to pip install the project without error :

* Use importlib to retrieve version (API added in python 3.8, if python 3.7 support must be kept the backport package https://pypi.org/project/importlib-metadata/ should be used).
* Remove analyzeMFT.py as a script to prevent conflict when installing the package.

This PR must be update depending if you wan't to kept support for python 3.7, or update minimal requirement to python 3.8 (or 3.9)

Thanks for your work,